### PR TITLE
Add birthday countdown to unlock site

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,2 +1,2 @@
 export const HER_NAME = 'Micah';
-export const BIRTHDAY = new Date('2025-09-13');
+export const BIRTHDAY = new Date('2025-09-13T00:00:00+08:00');

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -155,7 +155,7 @@ export default function Home() {
                         Opens in {days}d {hours}h {minutes}m {seconds}s
                     </p>
                     <p className="text-sm opacity-90">
-                        ({BIRTHDAY.toLocaleDateString()})
+                        ({BIRTHDAY.toLocaleDateString('en-US', { timeZone: 'Asia/Manila' })})
                     </p>
                 </div>
             )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,11 +24,22 @@ function getRandomImage() {
     return images[index];
 }
 
+function formatTime(ms: number) {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const days = Math.floor(totalSeconds / (3600 * 24));
+    const hours = Math.floor((totalSeconds % (3600 * 24)) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return {days, hours, minutes, seconds};
+}
+
 export default function Home() {
     const completed = getQuizCompleted();
 
     // state for the random image
     const [currentImage, setCurrentImage] = useState<string | null>(getRandomImage());
+
+    const [timeLeft, setTimeLeft] = useState(BIRTHDAY.getTime() - Date.now());
 
     const handleShowRandom = () => {
         setCurrentImage(getRandomImage());
@@ -37,8 +48,10 @@ export default function Home() {
 
 
     const birthdayToday = isBirthday();
-    const locked = !birthdayToday;
+    const locked = timeLeft > 0;
     const firedRef = useRef(false);
+
+    const {days, hours, minutes, seconds} = formatTime(timeLeft);
 
     useEffect(() => {
         if (!birthdayToday) {
@@ -49,6 +62,13 @@ export default function Home() {
         firedRef.current = true;
         random_celebrate();
     }, [birthdayToday]);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setTimeLeft(BIRTHDAY.getTime() - Date.now());
+        }, 1000);
+        return () => clearInterval(interval);
+    }, []);
     return (
         <div className="relative max-w-md mx-auto p-4 space-y-6 text-center">
             {/* Main content (dimmed when locked) */}
@@ -126,7 +146,10 @@ export default function Home() {
                     </svg>
                     <p className="text-lg font-semibold">Locked until her birthday</p>
                     <p className="text-sm opacity-90">
-                        Opens on {BIRTHDAY.toLocaleDateString()}
+                        Opens in {days}d {hours}h {minutes}m {seconds}s
+                    </p>
+                    <p className="text-sm opacity-90">
+                        ({BIRTHDAY.toLocaleDateString()})
                     </p>
                 </div>
             )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -65,7 +65,13 @@ export default function Home() {
 
     useEffect(() => {
         const interval = setInterval(() => {
-            setTimeLeft(BIRTHDAY.getTime() - Date.now());
+            const diff = BIRTHDAY.getTime() - Date.now();
+            if (diff <= 0) {
+                clearInterval(interval);
+                setTimeLeft(0);
+            } else {
+                setTimeLeft(diff);
+            }
         }, 1000);
         return () => clearInterval(interval);
     }, []);


### PR DESCRIPTION
## Summary
- show time remaining until September 13 at midnight
- unlock site automatically when countdown hits zero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3ea71c5b8832e95a0281b0d917fd9